### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "csharp"
+run = "Program"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Scientific-Notation-Converter
 It converts numbers to scientific notation and vis versa.
+
+[![Run on Repl.it](https://repl.it/badge/github/JTCG7684/Scientific-Notation-Converter)](https://repl.it/github/JTCG7684/Scientific-Notation-Converter)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JTCG7684/Scientific-Notation-Converter).